### PR TITLE
Use built-in django autodiscover modules method

### DIFF
--- a/hueyx/management/commands/run_hueyx.py
+++ b/hueyx/management/commands/run_hueyx.py
@@ -1,9 +1,8 @@
-import imp
 import logging
-import os
 
 from django.apps import apps as django_apps
 from django.core.management.base import BaseCommand
+from django.utils.module_loading import autodiscover_modules
 
 from huey.consumer_options import ConsumerConfig
 from hueyx.consumer import HueyxConsumer
@@ -25,23 +24,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('queue_name', nargs=1, type=str, help='Select the queue to listen on.')
 
-    def autodiscover(self):
-        """Use Django app registry to pull out potential apps with tasks.py module."""
-        module_name = 'tasks'
-        for config in django_apps.get_app_configs():
-            app_path = config.module.__path__
-            try:
-                fp, path, description = imp.find_module(module_name, app_path)
-            except ImportError:
-                continue
-            else:
-                import_path = '%s.%s' % (config.name, module_name)
-                try:
-                    imp.load_module(import_path, fp, path, description)
-                except ImportError:
-                    logger.exception('Found "%s" but error raised attempting '
-                                     'to load module.', import_path)
-
     def run_consumer(self, queue_name):
 
         multiple_scheduler_locking = self.consumer_options.pop('multiple_scheduler_locking', False)
@@ -60,6 +42,6 @@ class Command(BaseCommand):
         queue_name = options['queue_name'][0]
         self.consumer_options = settings_reader.configurations[queue_name].consumer_options
 
-        self.autodiscover()
+        autodiscover_modules("tasks")
         self.run_consumer(queue_name)
 


### PR DESCRIPTION
- The previous method was causing errors when importing tasks into views.py